### PR TITLE
Add roundmode type support

### DIFF
--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -1,7 +1,7 @@
 // hal_codegen.js
 
 function genRust(ast) {
-    let out = [];
+    let out = ["mod hal { type RoundMode = (); }"];
     for (const item of ast.items) {
         if (item.type === "Function") {
             out.push(genFunction(item));
@@ -18,6 +18,7 @@ function rustType(halType) {
         case "longint": return "i64";
         case "boolean": return "bool";
         case "string":  return "String";
+        case "roundmode": return "hal::RoundMode";
         default: return "/* unknown: " + halType + " */";
     }
 }
@@ -52,6 +53,7 @@ function defaultValueRust(halType) {
         case "longint":  return "0";
         case "boolean":  return "false";
         case "string":   return "String::new()";
+        case "roundmode": return "Default::default()";
         default:         return "Default::default()";
     }
 }

--- a/hal_lexer.js
+++ b/hal_lexer.js
@@ -13,7 +13,7 @@ const tokenSpecs = [
     ].map(kw => ({ type: kw.toUpperCase() + "_KEYWORD", regex: new RegExp("^" + kw + "\\b", "i") })),
     // Types
     ...[
-      "area", "boolean", "integer", "longint", "string", "val", "ulong64", "date", "time"
+      "area", "boolean", "integer", "longint", "string", "val", "ulong64", "date", "time", "roundmode"
     ].map(kw => ({ type: kw.toUpperCase() + "_TYPE", regex: new RegExp("^" + kw + "\\b", "i") })),
     // Literals
     { type: "STRING_LITERAL", regex: /^('(?:\\.|''|[^'\\])*'|"(?:\\.|""|[^"\\])*")/ },


### PR DESCRIPTION
## Summary
- support `roundmode` datatype in lexer and Rust codegen
- expose `hal::RoundMode` alias and prefix generated Rust

## Testing
- `node shalc.js hal/sample.hal`
