### PR TITLE
Handle external HAL subprograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A small experiment implementing a HAL (Hypothetical Assembly Language) parser an
 ## Usage
 
 1. Place your `.hal` source files anywhere in the project. A sample file is provided at `hal/sample.hal`.
+   Another file `hal/sample_external.hal` demonstrates declarations of external
+   functions and procedures.
 2. Run the compiler with Node.js, passing the path to the `.hal` file:
 
 ```bash

--- a/hal/sample_external.hal
+++ b/hal/sample_external.hal
@@ -1,0 +1,2 @@
+external function integer ext_add(integer a, integer b);
+external procedure ext_proc(integer x);

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -7,6 +7,9 @@ function genRust(ast) {
             out.push(genFunction(item));
         } else if (item.type === "Procedure") {
             out.push(genProcedure(item));
+        } else if (item.type === "ExternalFunction" || item.type === "ExternalProcedure") {
+            // External declarations have no body; emit a comment for now
+            out.push(`// external ${item.type === "ExternalFunction" ? "function" : "procedure"} ${item.name}`);
         }
     }
     return out.join("\n\n");


### PR DESCRIPTION
## Summary
- handle `external` function/procedure declarations correctly: external subprograms cannot have bodies and cannot be marked `global`
- keep emitting comment stubs for external declarations

## Testing
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/sample_external.hal`
- `node shalc.js /tmp/test.hal` *(fails: External function cannot have a body)*
- `node shalc.js /tmp/test2.hal` *(fails: Expected function body)*
- `node shalc.js /tmp/test3.hal` *(fails: 'external' and 'global' cannot be combined)*
