### PR TITLE
Update parser for sized strings and calls

### DIFF
--- a/hal/cutdecimals.hal
+++ b/hal/cutdecimals.hal
@@ -1,0 +1,11 @@
+global
+procedure CutDecimals(val nr, var string cutstr)
+begin
+  Integer ln;
+  String 200 nrstr;
+  
+  nrstr = "" & nr;
+  ln = Len(nrstr);
+  cutstr = Mid(nrstr,0,ln-3);
+  return;
+end;


### PR DESCRIPTION
## Summary
- support optional length specifier on string parameters
- require length when defining strings
- allow function calls and `&` concatenation
- generate Rust code for new constructs
- add `cutdecimals.hal` sample demonstrating these features
- inline builtin functions `Len` and `Mid`

## Testing
- `node shalc.js hal/cutdecimals.hal`
- `node shalc.js hal/sample.hal`
