### PR TITLE
Add parenthesized expression support

### DIFF
--- a/hal/sample.hal
+++ b/hal/sample.hal
@@ -2,7 +2,7 @@ global
 function integer foo(integer x, integer y)
 begin
     integer z;
-    z = x + y;
+    z = (x + y);
     return z;
 end;
 

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -136,6 +136,8 @@ function genExpr(expr) {
                 default:
                     return `${expr.callee}(${expr.args.map(a => genExpr(a)).join(", ")})`;
             }
+        case "ParenExpression":
+            return `(${genExpr(expr.expr)})`;
         default:
             return `/* Unhandled expr: ${expr.type} */`;
     }

--- a/hal_parser.js
+++ b/hal_parser.js
@@ -365,6 +365,12 @@ class Parser {
 
     parsePrimaryWithSymbols(symbolTable) {
         let t = this.peek();
+        if (t.type === "LPAREN") {
+            this.expect("LPAREN");
+            const expr = this.parseExpressionWithSymbols(symbolTable);
+            this.expect("RPAREN");
+            return { type: "ParenExpression", expr };
+        }
         if (t.type === "IDENTIFIER") {
             let id = this.expect("IDENTIFIER");
             if (this.peek().type === "LPAREN") {


### PR DESCRIPTION
## Summary
- parse parenthesized expressions
- generate parentheses in Rust output
- use a parenthesized expression in `sample.hal`

## Testing
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/control.hal`
- `node shalc.js hal/cutdecimals.hal`
- `node shalc.js hal/sample_external.hal`
