### PR TITLE
Add boolean operators

### DIFF
--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -116,11 +116,14 @@ function genExpr(expr) {
         case "Identifier":      return expr.name;
         case "NumberLiteral":   return expr.value.toString();
         case "StringLiteral":   return JSON.stringify(expr.value);
+        case "BooleanLiteral":  return expr.value ? "true" : "false";
         case "BinaryExpression":
             if (expr.operator === "AMPERSAND") {
                 return `format!(\"{}{}\", ${genExpr(expr.left)}, ${genExpr(expr.right)})`;
             }
             return `${genExpr(expr.left)} ${opRust(expr.operator)} ${genExpr(expr.right)}`;
+        case "UnaryExpression":
+            return `${opRust(expr.operator)}${genExpr(expr.argument)}`;
         case "CallExpression":
             switch (expr.callee.toLowerCase()) {
                 case "len":
@@ -155,6 +158,10 @@ function opRust(op) {
         case "GREATER_OR_EQUAL": return ">=";
         case "EQEQ": return "==";
         case "NOT_EQUALS": return "!=";
+        case "AND_KEYWORD": return "&&";
+        case "OR_KEYWORD": return "||";
+        case "NOT_KEYWORD": return "!";
+        case "NOT_OP": return "!";
         default: return op;
     }
 }

--- a/hal_lexer.js
+++ b/hal_lexer.js
@@ -9,7 +9,7 @@ const tokenSpecs = [
     // Keywords (longest first)
     ...[
       "otherwise", "procedure", "function", "external", "updating", "global", "begin", "end", "if", "then", "else", "for", "while", "repeat",
-      "var", "array", "record", "of", "return", "switch", "case", "const", "true", "false", "null", "window", "remote", "inner", "outer"
+      "var", "array", "record", "of", "return", "switch", "case", "const", "true", "false", "null", "window", "remote", "inner", "outer", "and", "or", "not"
     ].map(kw => ({ type: kw.toUpperCase() + "_KEYWORD", regex: new RegExp("^" + kw + "\\b", "i") })),
     // Types
     ...[


### PR DESCRIPTION
## Summary
- add `and`, `or`, `not` keywords to lexer
- parse boolean expressions with the right precedence
- support boolean literals and unary operators
- generate Rust code for boolean operators

## Testing
- `node shalc.js hal/sample.hal`