### PR TITLE
Add record variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,22 @@ This command writes a Rust file next to the input with the `.rs` extension (for 
 
 The provided `sample.hal` contains a global function `foo` and a procedure `bar`.
 After running the command above you will find `sample.rs` with the generated Rust code.
+
+### Record Variables
+
+The compiler understands simple `record` variable declarations such as:
+
+```
+record A a;
+```
+
+This will result in Rust code using the corresponding struct from a `datadef`
+module and initializing the variable with `Default::default()`:
+
+```
+use datadef::A;
+let mut a: A = Default::default();
+```
+
+Field accesses like `a.foo` are allowed without validating whether the field
+exists in the record.

--- a/hal/record_func.hal
+++ b/hal/record_func.hal
@@ -1,0 +1,6 @@
+function integer get_foo()
+begin
+    record A r;
+    r.foo = 2;
+    return r.foo;
+end;

--- a/hal/record_test.hal
+++ b/hal/record_test.hal
@@ -1,0 +1,5 @@
+procedure recproc()
+begin
+    record A a;
+    a.foo = 1;
+end;


### PR DESCRIPTION
## Summary
- implement `record` type parsing for variable declarations
- allow field access with '.' without record definition lookup
- update assignments and expressions for member access
- generate `use datadef::<Record>` and default init for record variables
- update examples and documentation

## Testing
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/record_test.hal && node shalc.js hal/record_func.hal`
