### PR TITLE
Add switch statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ let mut a: A = Default::default();
 
 Field accesses like `a.foo` are allowed without validating whether the field
 exists in the record.
+
+### Switch Statements
+
+Switch statements following the HAL syntax are supported and are translated into
+Rust `match` expressions.

--- a/hal/control.hal
+++ b/hal/control.hal
@@ -13,4 +13,12 @@ begin
     begin
         n = n - 1;
     end;
+    switch n of
+    case 0:
+        n = 1;
+    case 1:
+        n = 2;
+    otherwise
+        n = 3;
+    end;
 end;

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -79,6 +79,19 @@ function genBlock(block, paramNames = []) {
             code.push(indent(indent(updateLine)));
             code.push(indent(`}`));
             code.push(`}`);
+        } else if (stmt.type === "SwitchStatement") {
+            const disc = genExpr(stmt.discriminant);
+            let arms = [];
+            for (const cs of stmt.cases) {
+                const pat = cs.values.map(v => genExpr(v)).join(" | ");
+                const body = indent(genBlock({ statements: cs.body }));
+                arms.push(`${pat} => {\n${body}\n}`);
+            }
+            if (stmt.otherwise && stmt.otherwise.length > 0) {
+                const body = indent(genBlock({ statements: stmt.otherwise }));
+                arms.push(`_ => {\n${body}\n}`);
+            }
+            code.push(`match ${disc} {\n${indent(arms.join(",\n"))}\n}`);
         } else {
             code.push(`/* Unhandled statement: ${stmt.type} */`);
         }


### PR DESCRIPTION
## Summary
- add parsing logic for `switch` statements
- handle `SwitchStatement` in Rust code generation
- update control.hal sample with a switch
- document switch statement support

## Testing
- `for f in hal/*.hal; do node shalc.js $f > /tmp/out.log; echo "$f -> $?"; done`