### PR TITLE
Add label and goto parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ exists in the record.
 
 Switch statements following the HAL syntax are supported and are translated into
 Rust `match` expressions.
+
+### Labels and Goto
+
+Simple labels (`label:`) and `goto` statements are recognized by the parser.
+In the generated Rust code they currently appear as comments.

--- a/hal/goto_sample.hal
+++ b/hal/goto_sample.hal
@@ -1,0 +1,11 @@
+procedure testGoto(integer n)
+begin
+    integer i;
+    i = 0;
+label1:
+    if i < n then
+    begin
+        i = i + 1;
+        goto label1;
+    end;
+end;

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -54,6 +54,10 @@ function genBlock(block, paramNames = []) {
             }
         } else if (stmt.type === "ExpressionStatement") {
             code.push(`${genExpr(stmt.expr)};`);
+        } else if (stmt.type === "LabelStatement") {
+            code.push(`// label: ${stmt.label}`);
+        } else if (stmt.type === "GotoStatement") {
+            code.push(`// goto ${stmt.label}`);
         } else if (stmt.type === "IfStatement") {
             const cond = genExpr(stmt.condition);
             const thenCode = indent(genBlock(stmt.consequent));

--- a/hal_lexer.js
+++ b/hal_lexer.js
@@ -8,7 +8,7 @@ const tokenSpecs = [
     { type: "CRLF", regex: /^(\r\n|\r|\n)+/ },
     // Keywords (longest first)
     ...[
-      "otherwise", "procedure", "function", "external", "updating", "global", "begin", "end", "if", "then", "else", "for", "while", "repeat",
+      "otherwise", "procedure", "function", "external", "updating", "global", "begin", "end", "if", "then", "else", "for", "while", "repeat", "goto",
       "var", "array", "record", "of", "return", "switch", "case", "const", "true", "false", "null", "window", "remote", "inner", "outer", "and", "or", "not"
     ].map(kw => ({ type: kw.toUpperCase() + "_KEYWORD", regex: new RegExp("^" + kw + "\\b", "i") })),
     // Types

--- a/hal_parser.js
+++ b/hal_parser.js
@@ -224,6 +224,21 @@ class Parser {
     }
 
     parseStatementWithSymbols(symbolTable) {
+        // Label statement: <id> :
+        if (this.peek().type === "IDENTIFIER" && this.peek(1).type === "COLON") {
+            const label = this.expect("IDENTIFIER").value;
+            this.expect("COLON");
+            while (this.accept("SEMICOLON")) {}
+            return { type: "LabelStatement", label };
+        }
+
+        // Goto statement: goto <label>;
+        if (this.peek().type === "GOTO_KEYWORD") {
+            this.expect("GOTO_KEYWORD");
+            const label = this.expect("IDENTIFIER").value;
+            this.accept("SEMICOLON");
+            return { type: "GotoStatement", label };
+        }
         // Local variable declaration: <type> <id>[, <id>]* ;
         if (this.isTypeToken(this.peek())) {
             let decl = this.parseLocalVariableDeclaration();


### PR DESCRIPTION
## Summary
- add goto keyword to lexer
- parse label and goto statements in the parser
- emit comments in Rust code for labels and gotos
- document goto support in README
- add a goto example HAL file

## Testing
- `node shalc.js hal/goto_sample.hal`
- `node shalc.js hal/sample.hal`
