### PR TITLE
Add row type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ let mut a: A = Default::default();
 Field accesses like `a.foo` are allowed without validating whether the field
 exists in the record.
 
+### Row Variables
+
+`row` variables work the same way as `record` variables. The syntax is
+
+```
+row A r;
+```
+
+This currently generates the same Rust code as a `record` variable and simply
+initializes the struct with `Default::default()`.
+
 ### Switch Statements
 
 Switch statements following the HAL syntax are supported and are translated into

--- a/hal/row_test.hal
+++ b/hal/row_test.hal
@@ -1,0 +1,5 @@
+procedure rowproc()
+begin
+    row A r;
+    r.foo = 1;
+end;

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -24,7 +24,9 @@ function rustType(halType) {
         case "string":  return "String";
         case "roundmode": return "hal::RoundMode";
         case "val": return "f64";
-        case "record": return halType.record;
+        case "record":
+        case "row":
+            return halType.record;
         default: return "/* unknown: " + base + " */";
     }
 }
@@ -36,7 +38,7 @@ function genBlock(block, paramNames = []) {
     for (const stmt of block.statements) {
         if (stmt.type === "VarDeclaration") {
             for (const name of stmt.names) {
-                if (stmt.halType.base && stmt.halType.base.toLowerCase() === "record") {
+                if (stmt.halType.base && ["record", "row"].includes(stmt.halType.base.toLowerCase())) {
                     code.push(`use datadef::${stmt.halType.record};`);
                     code.push(`let mut ${name}: ${stmt.halType.record} = Default::default();`);
                 } else {

--- a/hal_lexer.js
+++ b/hal_lexer.js
@@ -9,7 +9,7 @@ const tokenSpecs = [
     // Keywords (longest first)
     ...[
       "otherwise", "procedure", "function", "external", "updating", "global", "begin", "end", "if", "then", "else", "for", "while", "repeat", "goto",
-      "var", "array", "record", "of", "return", "switch", "case", "const", "true", "false", "null", "window", "remote", "inner", "outer", "and", "or", "not"
+      "var", "array", "record", "row", "of", "return", "switch", "case", "const", "true", "false", "null", "window", "remote", "inner", "outer", "and", "or", "not"
     ].map(kw => ({ type: kw.toUpperCase() + "_KEYWORD", regex: new RegExp("^" + kw + "\\b", "i") })),
     // Types
     ...[

--- a/hal_parser.js
+++ b/hal_parser.js
@@ -297,11 +297,17 @@ class Parser {
             throw new ParseError(`Expected type but got ${token.type}`, token);
         }
 
-        // Handle "record <TypeName>" specially
+        // Handle "record <TypeName>" and "row <TypeName>" specially
         if (token.type === "RECORD_KEYWORD") {
             this.expect("RECORD_KEYWORD");
             const recordName = this.expect("IDENTIFIER").value;
             return { base: "record", record: recordName };
+        }
+        if (token.type === "ROW_KEYWORD") {
+            this.expect("ROW_KEYWORD");
+            const recordName = this.expect("IDENTIFIER").value;
+            // Treat row like record for now
+            return { base: "row", record: recordName };
         }
 
         let base = this.expect(token.type).value;


### PR DESCRIPTION
## Summary
- support `row` variables in lexer and parser
- handle `row` in Rust code generator
- document row variables in README
- add a simple row sample

## Testing
- `node shalc.js hal/row_test.hal`
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/record_test.hal`