### PR TITLE
Add primitive declarations and function table

### DIFF
--- a/hal/primitives.hal
+++ b/hal/primitives.hal
@@ -1,0 +1,3 @@
+external function integer len(string);
+external function string 9999 mid(string, integer, integer);
+external procedure OverrideLangCode();

--- a/shalc.js
+++ b/shalc.js
@@ -21,9 +21,19 @@ try {
     process.exit(1);
 }
 
+const builtinPath = path.join(__dirname, 'hal', 'primitives.hal');
+let builtinCode = '';
+try {
+    builtinCode = fs.readFileSync(builtinPath, 'utf8');
+} catch (e) {
+    // If the file doesn't exist simply continue with empty builtins
+}
+
 let ast;
 try {
-    ast = parse(code);
+    const { ast: builtins, functionTable } = parse(builtinCode);
+    const { ast: userAst } = parse(code, functionTable);
+    ast = { type: 'Program', items: [...builtins.items, ...userAst.items] };
 } catch (e) {
     if (e instanceof ParseError) {
         console.error(e.message);


### PR DESCRIPTION
## Summary
- include builtin primitive declarations in `hal/primitives.hal`
- extend `hal_parser.js` with function table and checking for call undefinedness
- support string length in function return types
- automatically parse the primitive declarations in `shalc.js`

## Testing
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/sample_external.hal`