### PR TITLE
Add zero-arg procedure call support

### DIFF
--- a/hal/proc_call.hal
+++ b/hal/proc_call.hal
@@ -1,0 +1,9 @@
+procedure noproc()
+begin
+end;
+
+procedure test()
+begin
+    overridelangcode;
+    noproc;
+end;


### PR DESCRIPTION
## Summary
- allow parser to recognise procedure calls with no parameters even when no parentheses are used
- add sample `proc_call.hal` demonstrating this behaviour

## Testing
- `node shalc.js hal/proc_call.hal`
- `node shalc.js hal/sample.hal`