### PR TITLE
Add support for assigning to function name

### DIFF
--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -127,7 +127,10 @@ function genFunction(fn) {
     ).join(", ");
     const retType = rustType(fn.returnType) || "i32";
     const pub = fn.modifiers && fn.modifiers.includes("GLOBAL_KEYWORD") ? "pub " : "";
-    return `${pub}fn ${fn.name}(${params}) -> ${retType} {\n${indent(genBlock(fn.body, fn.params.map(p => p.name)))}\n}`;
+    const retVarDecl = `let mut ${fn.name}: ${retType} = ${defaultValueRust(fn.returnType)};`;
+    const body = genBlock(fn.body, fn.params.map(p => p.name).concat(fn.name));
+    const retLine = `return ${fn.name};`;
+    return `${pub}fn ${fn.name}(${params}) -> ${retType} {\n${indent(retVarDecl)}\n${indent(body)}\n${indent(retLine)}\n}`;
 }
 
 function genProcedure(proc) {


### PR DESCRIPTION
## Summary
- track current function name in parser
- allow assignments and references to the current function name
- emit a return variable in generated Rust functions

## Testing
- `node shalc.js hal/sample.hal`
- `for f in hal/*.hal; do node shalc.js "$f"; done`