### PR TITLE
Allow zero-arg function call without parens

### DIFF
--- a/hal/roundmode_test.hal
+++ b/hal/roundmode_test.hal
@@ -1,0 +1,5 @@
+procedure roundmode_test()
+begin
+    roundmode rnddef;
+    rnddef = DefaultValRoundoff;
+end;

--- a/hal_parser.js
+++ b/hal_parser.js
@@ -582,7 +582,16 @@ class Parser {
                     return node;
                 }
                 const entry = this.functionTable.get(idToken.value.toLowerCase());
-                if (entry && entry.params.length === 0 && (entry.kind === "Procedure" || entry.kind === "ExternalProcedure")) {
+                if (
+                    entry &&
+                    entry.params.length === 0 &&
+                    (
+                        entry.kind === "Procedure" ||
+                        entry.kind === "ExternalProcedure" ||
+                        entry.kind === "Function" ||
+                        entry.kind === "ExternalFunction"
+                    )
+                ) {
                     return { type: "CallExpression", callee: idToken.value, args: [] };
                 }
                 throw new ParseError(`Variable '${idToken.value}' is not declared`, idToken);


### PR DESCRIPTION
## Summary
- parse HAL zero-arg function names as implicit calls
- add roundmode test case covering DefaultValRoundoff primitive

## Testing
- `node shalc.js hal/roundmode_test.hal`
- `for f in hal/*.hal; do node shalc.js "$f" >/dev/null; done`