### PR TITLE
Implement async queue prefix for procedure calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ Rust `match` expressions.
 
 Simple labels (`label:`) and `goto` statements are recognized by the parser.
 In the generated Rust code they currently appear as comments.
+
+### Async Procedure Calls
+
+Procedure calls can optionally be prefixed with an asynchronous queue name
+followed by a period. Currently the predefined queue is `clientremoteasync`.
+A call like
+
+```hal
+clientremoteasync.MyProc(1);
+```
+
+is parsed and emitted as a commented placeholder in the generated Rust code.

--- a/doc/Hal.bnf
+++ b/doc/Hal.bnf
@@ -621,6 +621,10 @@ call_suffix ::= LPAREN argument_list? RPAREN {
     getFunctionName
   ]
 }
+// Prefixing a procedure call with an async queue name is allowed.
+// Use a period between the queue name and the procedure.
+// Example: clientremoteasync.MyProc(arg);
+// Currently only clientremoteasync is predefined.
 argument_list ::= expr (COMMA expr)*
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/hal/primitives.hal
+++ b/hal/primitives.hal
@@ -9,3 +9,4 @@ external function boolean nonblank(string);
 external procedure overridelangcode();
 external function boolean readfirstmain(record namevc, integer, boolean);
 external function val round(val, roundmode);
+external procedure do_displaywarning(string);

--- a/hal/proc_call.hal
+++ b/hal/proc_call.hal
@@ -6,4 +6,5 @@ procedure test()
 begin
     overridelangcode;
     noproc;
+    clientremoteasync.Do_DisplayWarning("hello");
 end;

--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -100,6 +100,9 @@ function genBlock(block, paramNames = []) {
                 arms.push(`_ => {\n${body}\n}`);
             }
             code.push(`match ${disc} {\n${indent(arms.join(",\n"))}\n}`);
+        } else if (stmt.type === "AsyncCallStatement") {
+            const args = stmt.args.map(a => genExpr(a)).join(", ");
+            code.push(`// async ${stmt.queue}.${stmt.callee}(${args})`);
         } else {
             code.push(`/* Unhandled statement: ${stmt.type} */`);
         }


### PR DESCRIPTION
## Summary
- add new external procedure `do_displaywarning`
- support async procedure calls prefixed by a queue name followed by a period
- emit async procedure calls as comments in Rust codegen
- document async call syntax and queue support
- update sample `proc_call.hal` to demonstrate new syntax

## Testing
- `node shalc.js hal/proc_call.hal`
- `node shalc.js hal/sample.hal`
