### PR TITLE
Add simple goto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Rust `match` expressions.
 
 ### Labels and Goto
 
-Simple labels (`label:`) and `goto` statements are recognized by the parser.
-In the generated Rust code they currently appear as comments.
+Simple labels (`label:`) and `goto` statements are translated to Rust labelled
+loops. A `goto` that jumps back to a previously defined label becomes a
+`continue` to that loop.
 
 ### Async Procedure Calls
 


### PR DESCRIPTION
## Summary
- handle labels and backward goto statements in the Rust code generator
- document goto and label code generation

## Testing
- `node shalc.js hal/goto_sample.hal`
- `node shalc.js hal/sample.hal`