### PR TITLE
Add builtin use declarations in generated Rust

### DIFF
--- a/hal_codegen_rust.js
+++ b/hal_codegen_rust.js
@@ -1,7 +1,18 @@
 // hal_codegen.js
 
-function genRust(ast) {
+function genRust(ast, builtins = []) {
     let out = ["mod hal { type RoundMode = (); }"];
+
+    if (builtins.length > 0) {
+        const names = Array.from(new Set(
+            builtins
+                .filter(b => b.type === "ExternalFunction" || b.type === "ExternalProcedure")
+                .map(b => b.name)
+        ));
+        if (names.length > 0) {
+            out.push(names.map(n => `use builtin::${n};`).join("\n"));
+        }
+    }
     for (const item of ast.items) {
         if (item.type === "Function") {
             out.push(genFunction(item));

--- a/shalc.js
+++ b/shalc.js
@@ -30,10 +30,12 @@ try {
 }
 
 let ast;
+let builtinItems = [];
 try {
     const { ast: builtins, functionTable } = parse(builtinCode);
     const { ast: userAst } = parse(code, functionTable);
     ast = { type: 'Program', items: [...builtins.items, ...userAst.items] };
+    builtinItems = builtins.items;
 } catch (e) {
     if (e instanceof ParseError) {
         console.error(e.message);
@@ -43,7 +45,7 @@ try {
     }
 }
 
-const rust = genRust(ast) + "\n";
+const rust = genRust(ast, builtinItems) + "\n";
 const outPath = path.join(
     path.dirname(inputPath),
     path.basename(inputPath, '.hal') + '.rs'


### PR DESCRIPTION
## Summary
- generate `use builtin::<name>` statements for primitives.hal externals
- pass builtin items to Rust code generator

## Testing
- `node shalc.js hal/sample.hal`
- `node shalc.js hal/record_test.hal`
