### PR TITLE
Switch backend to JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shalc
 
-A small experiment implementing a HAL (Hypothetical Assembly Language) parser and a simple Rust code generator.
+A small experiment implementing a HAL (Hypothetical Assembly Language) parser and a simple JavaScript code generator.
 
 ## Usage
 
@@ -13,12 +13,12 @@ A small experiment implementing a HAL (Hypothetical Assembly Language) parser an
 node shalc.js hal/sample.hal
 ```
 
-This command writes a Rust file next to the input with the `.rs` extension (for the sample above, `hal/sample.rs`).
+This command writes a JavaScript file next to the input with the `.js` extension (for the sample above, `hal/sample.js`).
 
 ## Sample
 
 The provided `sample.hal` contains a global function `foo` and a procedure `bar`.
-After running the command above you will find `sample.rs` with the generated Rust code.
+After running the command above you will find `sample.js` with the generated JavaScript code.
 
 ### Record Variables
 
@@ -28,12 +28,10 @@ The compiler understands simple `record` variable declarations such as:
 record A a;
 ```
 
-This will result in Rust code using the corresponding struct from a `datadef`
-module and initializing the variable with `Default::default()`:
+This will result in JavaScript code using a plain object initialized to `{}`:
 
 ```
-use datadef::A;
-let mut a: A = Default::default();
+let a = {};
 ```
 
 Field accesses like `a.foo` are allowed without validating whether the field
@@ -47,8 +45,8 @@ exists in the record.
 row A r;
 ```
 
-This currently generates the same Rust code as a `record` variable and simply
-initializes the struct with `Default::default()`.
+This currently generates the same JavaScript code as a `record` variable and simply
+initializes the object with `{}`.
 
 ### Array Variables
 
@@ -58,19 +56,19 @@ Array variables can be declared using the `array` keyword:
 array integer nums;
 ```
 
-Indexing expressions like `nums[0]` are supported and translated to Rust vector
-syntax. Array variables become `Vec` types in the generated Rust code.
+Indexing expressions like `nums[0]` are supported and translated to JavaScript array
+syntax. Array variables become regular arrays in the generated JavaScript code.
 
 ### Switch Statements
 
 Switch statements following the HAL syntax are supported and are translated into
-Rust `match` expressions.
+JavaScript `switch` statements.
 
 ### Labels and Goto
 
-Simple labels (`label:`) and `goto` statements are translated to Rust labelled
-loops. A `goto` that jumps back to a previously defined label becomes a
-`continue` to that loop.
+Simple labels (`label:`) and `goto` statements are translated using a simple
+state machine with labelled loops in JavaScript. A `goto` that jumps back to a
+previously defined label becomes a `continue` to that loop.
 
 ### Async Procedure Calls
 
@@ -82,4 +80,4 @@ A call like
 clientremoteasync.MyProc(1);
 ```
 
-is parsed and emitted as a commented placeholder in the generated Rust code.
+is parsed and emitted as a commented placeholder in the generated JavaScript code.

--- a/hal_codegen_js.js
+++ b/hal_codegen_js.js
@@ -1,0 +1,304 @@
+// hal_codegen_js.js
+
+function genJS(ast, builtins = []) {
+    const out = [];
+    for (const item of ast.items) {
+        if (item.type === 'Function') {
+            out.push(genFunction(item));
+        } else if (item.type === 'Procedure') {
+            out.push(genProcedure(item));
+        } else if (item.type === 'ExternalFunction' || item.type === 'ExternalProcedure') {
+            out.push(`// external ${item.type === 'ExternalFunction' ? 'function' : 'procedure'} ${item.name}`);
+        }
+    }
+    return out.join('\n\n');
+}
+
+function defaultValueJS(halType) {
+    const base = typeof halType === 'object' ? halType.base : halType;
+    switch ((base || '').toLowerCase()) {
+        case 'integer':
+        case 'longint':
+        case 'val':
+            return '0';
+        case 'boolean':
+            return 'false';
+        case 'string':
+            return '""';
+        case 'array':
+            return '[]';
+        case 'record':
+        case 'row':
+            return '{}';
+        default:
+            return 'null';
+    }
+}
+
+let currentFunctionName = null;
+
+function genBlock(block, paramNames = [], ctx = null) {
+    let code = [];
+    let openLabel = null;
+    for (const stmt of block.statements) {
+        if (stmt.type === 'VarDeclaration') {
+            for (const name of stmt.names) {
+                code.push(`let ${name} = ${defaultValueJS(stmt.halType)};`);
+            }
+        } else if (stmt.type === 'Assignment') {
+            code.push(`${genExpr(stmt.left)} = ${genExpr(stmt.expr)};`);
+        } else if (stmt.type === 'Return') {
+            if (stmt.expr) {
+                code.push(`return ${genExpr(stmt.expr)};`);
+            } else {
+                if (currentFunctionName) {
+                    code.push(`return ${currentFunctionName};`);
+                } else {
+                    code.push('return;');
+                }
+            }
+        } else if (stmt.type === 'ExpressionStatement') {
+            code.push(`${genExpr(stmt.expr)};`);
+        } else if (stmt.type === 'LabelStatement') {
+            if (ctx) continue;
+            if (openLabel) {
+                code.push('break;');
+                code.push('}');
+            }
+            code.push(`${stmt.label}: while (true) {`);
+            openLabel = stmt.label;
+        } else if (stmt.type === 'GotoStatement') {
+            if (ctx) {
+                const target = ctx.labelMap.get(stmt.label);
+                code.push(`${ctx.pcVar} = ${target};`);
+                code.push(`continue ${ctx.loopLabel};`);
+            } else {
+                code.push(`continue ${stmt.label};`);
+            }
+        } else if (stmt.type === 'IfStatement') {
+            const cond = genExpr(stmt.condition);
+            const thenCode = indent(genBlock(stmt.consequent, [], ctx));
+            if (stmt.alternate) {
+                const elseCode = indent(genBlock(stmt.alternate, [], ctx));
+                code.push(`if (${cond}) {\n${thenCode}\n} else {\n${elseCode}\n}`);
+            } else {
+                code.push(`if (${cond}) {\n${thenCode}\n}`);
+            }
+        } else if (stmt.type === 'WhileStatement') {
+            const cond = genExpr(stmt.condition);
+            const body = indent(genBlock(stmt.body, [], ctx));
+            code.push(`while (${cond}) {\n${body}\n}`);
+        } else if (stmt.type === 'ForStatement') {
+            const initLine = `${genExpr(stmt.init.left)} = ${genExpr(stmt.init.expr)};`;
+            const cond = genExpr(stmt.condition);
+            const updateLine = `${genExpr(stmt.update.left)} = ${genExpr(stmt.update.expr)};`;
+            const body = indent(genBlock(stmt.body, [], ctx));
+            code.push('{');
+            code.push(indent(initLine));
+            code.push(indent(`while (${cond}) {`));
+            code.push(indent(indent(body)));
+            code.push(indent(indent(updateLine)));
+            code.push(indent('}'));
+            code.push('}');
+        } else if (stmt.type === 'SwitchStatement') {
+            const disc = genExpr(stmt.discriminant);
+            code.push(`switch (${disc}) {`);
+            for (const cs of stmt.cases) {
+                for (const v of cs.values) {
+                    code.push(`case ${genExpr(v)}:`);
+                }
+                const body = indent(genBlock({ statements: cs.body }, [], ctx));
+                code.push(body);
+                code.push('break;');
+            }
+            if (stmt.otherwise && stmt.otherwise.length > 0) {
+                code.push('default:');
+                const body = indent(genBlock({ statements: stmt.otherwise }, [], ctx));
+                code.push(body);
+                code.push('break;');
+            }
+            code.push('}');
+        } else if (stmt.type === 'AsyncCallStatement') {
+            const args = stmt.args.map(a => genExpr(a)).join(', ');
+            code.push(`// async ${stmt.queue}.${stmt.callee}(${args})`);
+        } else {
+            code.push(`/* Unhandled statement: ${stmt.type} */`);
+        }
+    }
+    if (openLabel && !ctx) {
+        code.push('break;');
+        code.push('}');
+    }
+    return code.join('\n');
+}
+
+function genFunction(fn) {
+    const params = fn.params.map(p => p.name).join(', ');
+    const retVarDecl = `let ${fn.name} = ${defaultValueJS(fn.returnType)};`;
+    currentFunctionName = fn.name;
+    const { decls, matchCode } = genBasicBlocks(fn.body, fn.params.map(p => p.name).concat(fn.name));
+    currentFunctionName = null;
+    const lines = [retVarDecl];
+    if (decls) lines.push(decls);
+    lines.push('let pc = 0;');
+    lines.push(`${ctxLabel('pc_loop')}: while (true) {`);
+    lines.push(indent(matchCode));
+    lines.push('}');
+    lines.push(`return ${fn.name};`);
+    return `function ${fn.name}(${params}) {\n${indent(lines.join('\n'))}\n}`;
+}
+
+function genProcedure(proc) {
+    const params = proc.params.map(p => p.name).join(', ');
+    const { decls, matchCode } = genBasicBlocks(proc.body, proc.params.map(p => p.name));
+    const lines = [];
+    if (decls) lines.push(decls);
+    lines.push('let pc = 0;');
+    lines.push(`${ctxLabel('pc_loop')}: while (true) {`);
+    lines.push(indent(matchCode));
+    lines.push('}');
+    return `function ${proc.name}(${params}) {\n${indent(lines.join('\n'))}\n}`;
+}
+
+function genExpr(expr) {
+    switch (expr.type) {
+        case 'Identifier':
+            return expr.name;
+        case 'NumberLiteral':
+            return expr.value.toString();
+        case 'StringLiteral':
+            return JSON.stringify(expr.value);
+        case 'BooleanLiteral':
+            return expr.value ? 'true' : 'false';
+        case 'BinaryExpression':
+            if (expr.operator === 'AMPERSAND') {
+                return `${genExpr(expr.left)} + ${genExpr(expr.right)}`;
+            }
+            return `${genExpr(expr.left)} ${opJS(expr.operator)} ${genExpr(expr.right)}`;
+        case 'UnaryExpression':
+            return `${opJS(expr.operator)}${genExpr(expr.argument)}`;
+        case 'CallExpression':
+            switch (expr.callee.toLowerCase()) {
+                case 'len':
+                    return `${genExpr(expr.args[0])}.length`;
+                case 'mid': {
+                    const s = genExpr(expr.args[0]);
+                    const start = genExpr(expr.args[1]);
+                    const len = genExpr(expr.args[2]);
+                    return `${s}.substring(${start}, ${start} + ${len})`;
+                }
+                default:
+                    return `${expr.callee}(${expr.args.map(a => genExpr(a)).join(', ')})`;
+            }
+        case 'MemberExpression':
+            return `${genExpr(expr.object)}.${expr.property}`;
+        case 'IndexExpression':
+            return `${genExpr(expr.array)}[${genExpr(expr.index)}]`;
+        case 'ParenExpression':
+            return `(${genExpr(expr.expr)})`;
+        default:
+            return `/* Unhandled expr: ${expr.type} */`;
+    }
+}
+
+function opJS(op) {
+    switch (op) {
+        case 'PLUS': return '+';
+        case 'MINUS': return '-';
+        case 'MULTIPLY': return '*';
+        case 'DIVIDE': return '/';
+        case 'LESS': return '<';
+        case 'LESS_OR_EQUAL': return '<=';
+        case 'GREATER': return '>';
+        case 'GREATER_OR_EQUAL': return '>=';
+        case 'EQEQ': return '==';
+        case 'NOT_EQUALS': return '!=';
+        case 'AND_KEYWORD': return '&&';
+        case 'OR_KEYWORD': return '||';
+        case 'NOT_KEYWORD': return '!';
+        case 'NOT_OP': return '!';
+        default: return op;
+    }
+}
+
+function indent(str, prefix = '    ') {
+    return str.split('\n').map(line => prefix + line).join('\n');
+}
+
+function ctxLabel(label) {
+    return label;
+}
+
+function splitIntoBlocks(statements) {
+    let blocks = [];
+    let current = { label: null, stmts: [] };
+    for (const stmt of statements) {
+        if (stmt.type === 'VarDeclaration') {
+            continue;
+        }
+        if (stmt.type === 'LabelStatement') {
+            if (current.stmts.length > 0 || current.label !== null) {
+                blocks.push(current);
+            }
+            current = { label: stmt.label, stmts: [] };
+        } else {
+            current.stmts.push(stmt);
+            if (stmt.type === 'GotoStatement' || stmt.type === 'Return') {
+                blocks.push(current);
+                current = { label: null, stmts: [] };
+            }
+        }
+    }
+    if (current.stmts.length > 0 || current.label !== null) {
+        blocks.push(current);
+    }
+    return blocks;
+}
+
+function endsWithJump(stmts) {
+    if (stmts.length === 0) return false;
+    const last = stmts[stmts.length - 1];
+    return last.type === 'GotoStatement' || last.type === 'Return';
+}
+
+function genBasicBlockBody(block, ctx, nextPc) {
+    const body = genBlock({ statements: block.stmts }, [], ctx);
+    let lines = body ? body.split('\n') : [];
+    if (!endsWithJump(block.stmts)) {
+        if (nextPc === null) {
+            lines.push(`break ${ctx.loopLabel};`);
+        } else {
+            lines.push(`${ctx.pcVar} = ${nextPc};`);
+            lines.push(`continue ${ctx.loopLabel};`);
+        }
+    }
+    return lines.join('\n');
+}
+
+function genBasicBlocks(block, paramNames) {
+    const blocks = splitIntoBlocks(block.statements);
+    const labelMap = new Map();
+    for (let i = 0; i < blocks.length; i++) {
+        if (blocks[i].label) {
+            labelMap.set(blocks[i].label, i);
+        }
+    }
+    const ctx = { labelMap, pcVar: 'pc', loopLabel: 'pc_loop' };
+    let arms = [];
+    for (let i = 0; i < blocks.length; i++) {
+        const nextPc = i + 1 < blocks.length ? i + 1 : null;
+        const body = genBasicBlockBody(blocks[i], ctx, nextPc);
+        arms.push(`case ${i}:\n${indent(body)}\nbreak;`);
+    }
+    arms.push(`default:\n    break ${ctx.loopLabel};`);
+    let decls = [];
+    for (const stmt of block.statements) {
+        if (stmt.type === 'VarDeclaration') {
+            decls.push(genBlock({ statements: [stmt] }, paramNames, null));
+        }
+    }
+    const matchCode = `switch (pc) {\n${indent(arms.join('\n'))}\n}`;
+    return { decls: decls.join('\n'), matchCode };
+}
+
+module.exports = { genJS };

--- a/shalc.js
+++ b/shalc.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parse, ParseError } = require('./hal_parser');
-const { genRust } = require('./hal_codegen_rust');
+const { genJS } = require('./hal_codegen_js');
 
 function usage() {
     console.error('Usage: node shalc.js <file.hal>');
@@ -45,14 +45,14 @@ try {
     }
 }
 
-const rust = genRust(ast, builtinItems) + "\n";
+const js = genJS(ast, builtinItems) + "\n";
 const outPath = path.join(
     path.dirname(inputPath),
-    path.basename(inputPath, '.hal') + '.rs'
+    path.basename(inputPath, '.hal') + '.js'
 );
 
 try {
-    fs.writeFileSync(outPath, rust);
+    fs.writeFileSync(outPath, js);
     console.log(`Written ${outPath}`);
 } catch (e) {
     console.error(`Failed to write output: ${outPath}`);


### PR DESCRIPTION
## Summary
- replace Rust backend with a JavaScript code generator
- generate `.js` files when compiling
- document the JavaScript backend in the README

## Testing
- `node shalc.js hal/sample.hal`