### PR TITLE
Simpler JS generation

### DIFF
--- a/hal_codegen_js.js
+++ b/hal_codegen_js.js
@@ -1,12 +1,14 @@
 // hal_codegen_js.js
 
+const { hasLabelOrGoto } = require('./hal_opt');
+
 function genJS(ast, builtins = []) {
     const out = [];
     for (const item of ast.items) {
         if (item.type === 'Function') {
-            out.push(genFunction(item));
+            out.push(hasLabelOrGoto(item.body) ? genFunction(item) : genSimpleFunction(item));
         } else if (item.type === 'Procedure') {
-            out.push(genProcedure(item));
+            out.push(hasLabelOrGoto(item.body) ? genProcedure(item) : genSimpleProcedure(item));
         } else if (item.type === 'ExternalFunction' || item.type === 'ExternalProcedure') {
             out.push(`// external ${item.type === 'ExternalFunction' ? 'function' : 'procedure'} ${item.name}`);
         }
@@ -157,6 +159,22 @@ function genProcedure(proc) {
     lines.push(`${ctxLabel('pc_loop')}: while (true) {`);
     lines.push(indent(matchCode));
     lines.push('}');
+    return `function ${proc.name}(${params}) {\n${indent(lines.join('\n'))}\n}`;
+}
+
+function genSimpleFunction(fn) {
+    const params = fn.params.map(p => p.name).join(', ');
+    currentFunctionName = null;
+    const body = genBlock(fn.body, fn.params.map(p => p.name), null);
+    const lines = ['// collapsed the loop + switch:', body];
+    return `function ${fn.name}(${params}) {\n${indent(lines.join('\n'))}\n}`;
+}
+
+function genSimpleProcedure(proc) {
+    const params = proc.params.map(p => p.name).join(', ');
+    currentFunctionName = null;
+    const body = genBlock(proc.body, proc.params.map(p => p.name), null);
+    const lines = ['// collapsed the loop + switch:', body];
     return `function ${proc.name}(${params}) {\n${indent(lines.join('\n'))}\n}`;
 }
 

--- a/hal_opt.js
+++ b/hal_opt.js
@@ -1,0 +1,106 @@
+function hasLabelOrGoto(block) {
+    for (const stmt of block.statements) {
+        switch (stmt.type) {
+            case 'LabelStatement':
+            case 'GotoStatement':
+                return true;
+            case 'IfStatement':
+                if (hasLabelOrGoto(stmt.consequent)) return true;
+                if (stmt.alternate && hasLabelOrGoto(stmt.alternate)) return true;
+                break;
+            case 'WhileStatement':
+            case 'ForStatement':
+                if (hasLabelOrGoto(stmt.body)) return true;
+                break;
+            case 'SwitchStatement':
+                for (const cs of stmt.cases) {
+                    if (hasLabelOrGoto({ statements: cs.body })) return true;
+                }
+                if (stmt.otherwise && hasLabelOrGoto({ statements: stmt.otherwise })) return true;
+                break;
+            default:
+                break;
+        }
+    }
+    return false;
+}
+
+function isSimpleBlock(block) {
+    return block.statements.every(s =>
+        s.type === 'VarDeclaration' ||
+        s.type === 'Assignment' ||
+        s.type === 'Return');
+}
+
+function clone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+function substituteExpr(expr, env) {
+    switch (expr.type) {
+        case 'Identifier':
+            return env.has(expr.name) ? clone(env.get(expr.name)) : clone(expr);
+        case 'BinaryExpression':
+            return {
+                type: 'BinaryExpression',
+                operator: expr.operator,
+                left: substituteExpr(expr.left, env),
+                right: substituteExpr(expr.right, env)
+            };
+        case 'UnaryExpression':
+            return {
+                type: 'UnaryExpression',
+                operator: expr.operator,
+                argument: substituteExpr(expr.argument, env)
+            };
+        case 'ParenExpression':
+            return { type: 'ParenExpression', expr: substituteExpr(expr.expr, env) };
+        default:
+            return clone(expr);
+    }
+}
+
+function optimizeSimpleBlock(block, returnName) {
+    const env = new Map();
+    const out = [];
+    for (const stmt of block.statements) {
+        if (stmt.type === 'VarDeclaration') {
+            continue; // drop
+        } else if (stmt.type === 'Assignment') {
+            if (stmt.left.type === 'Identifier') {
+                env.set(stmt.left.name, substituteExpr(stmt.expr, env));
+            } else {
+                out.push({
+                    type: 'Assignment',
+                    left: substituteExpr(stmt.left, env),
+                    expr: substituteExpr(stmt.expr, env)
+                });
+            }
+        } else if (stmt.type === 'Return') {
+            let expr = stmt.expr ? substituteExpr(stmt.expr, env) : null;
+            if (!expr && env.has(returnName)) {
+                expr = substituteExpr(env.get(returnName), env);
+            }
+            out.push({ type: 'Return', expr });
+        }
+    }
+    return { type: 'Block', statements: out };
+}
+
+function removeDeadCode(ast) {
+    const newItems = [];
+    for (const item of ast.items) {
+        if ((item.type === 'Function' || item.type === 'Procedure')) {
+            if (!item.modifiers || !item.modifiers.includes('GLOBAL_KEYWORD')) {
+                continue; // drop non-global
+            }
+            if (!hasLabelOrGoto(item.body) && isSimpleBlock(item.body)) {
+                item.body = optimizeSimpleBlock(item.body, item.type === 'Function' ? item.name : null);
+            }
+            newItems.push(item);
+        }
+    }
+    return { type: 'Program', items: newItems };
+}
+
+module.exports = { removeDeadCode, hasLabelOrGoto };

--- a/shalc.js
+++ b/shalc.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { parse, ParseError } = require('./hal_parser');
 const { genJS } = require('./hal_codegen_js');
+const { removeDeadCode } = require('./hal_opt');
 
 function usage() {
     console.error('Usage: node shalc.js <file.hal>');
@@ -35,6 +36,7 @@ try {
     const { ast: builtins, functionTable } = parse(builtinCode);
     const { ast: userAst } = parse(code, functionTable);
     ast = { type: 'Program', items: [...builtins.items, ...userAst.items] };
+    ast = removeDeadCode(ast);
     builtinItems = builtins.items;
 } catch (e) {
     if (e instanceof ParseError) {
@@ -45,7 +47,7 @@ try {
     }
 }
 
-const js = genJS(ast, builtinItems) + "\n";
+const js = genJS(ast, []) + "\n";
 const outPath = path.join(
     path.dirname(inputPath),
     path.basename(inputPath, '.hal') + '.js'


### PR DESCRIPTION
## Summary
- add simple dead code elimination to strip unused declarations
- collapse blocks without labels or gotos
- generate simplified JS functions when possible

## Testing
- `node shalc.js hal/sample.hal`