### PR TITLE
Fix Python code generation for string concatenation

### DIFF
--- a/hal_codegen_python.js
+++ b/hal_codegen_python.js
@@ -157,7 +157,11 @@ function genExpr(expr) {
         case 'BooleanLiteral':  return expr.value ? 'True' : 'False';
         case 'BinaryExpression':
             if (expr.operator === 'AMPERSAND') {
-                return `${genExpr(expr.left)} + ${genExpr(expr.right)}`;
+                const leftExpr = genExpr(expr.left);
+                const rightExpr = genExpr(expr.right);
+                const left = expr.left.type === 'StringLiteral' ? leftExpr : `str(${leftExpr})`;
+                const right = expr.right.type === 'StringLiteral' ? rightExpr : `str(${rightExpr})`;
+                return `${left} + ${right}`;
             }
             return `${genExpr(expr.left)} ${opPython(expr.operator)} ${genExpr(expr.right)}`;
         case 'UnaryExpression':


### PR DESCRIPTION
## Summary
- ensure string concatenation uses `str()` where needed in Python codegen

## Testing
- `node shalc.js --python hal/sample.hal > /tmp/out.txt && nl -ba hal/sample.py | sed -n '48,52p'`